### PR TITLE
Feature add load button

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://www.youtube.com/watch?v=M_rEZaOYFac
 This plugin uses a WaveNet model to recreate the sound of real world hardware. The current version
 models a small tube amp, with the ability to add more options in the future. There is a clean/lead channel, 
 which is equivalent to the amp's clean and full drive settings. Gain and EQ knobs were added to 
-modulate the modeled sound.  
+modulate the modeled sound.
 
 ![app](https://github.com/keyth72/SmartGuitarAmp/blob/master/resources/amp_pic.png)
 

--- a/plugins/SmartAmp/SmartAmp.jucer
+++ b/plugins/SmartAmp/SmartAmp.jucer
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <JUCERPROJECT id="ym7AY5" name="SmartAmp" projectType="audioplug" pluginAUMainType="'aufx'"
-              companyName="HandDrawnAmps" headerPath="$(HOME)/eigen/" displaySplashScreen="1"
+              companyName="GuitarML" headerPath="$(HOME)/eigen/" displaySplashScreen="1"
               jucerFormatVersion="1" pluginCode="sa1" maxBinaryFileSize="20971520">
   <MAINGROUP id="ZrSGof" name="SmartAmp">
     <GROUP id="{0250E2E8-A733-0AA7-0A08-97085228CF87}" name="Resources">
@@ -85,7 +85,7 @@
     <VS2019 targetFolder="Builds/VisualStudio2019">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="SmartAmp"/>
-        <CONFIGURATION isDebug="0" name="Release" targetName="SmartAmp"/>
+        <CONFIGURATION isDebug="0" name="Release" targetName="SmartAmp" headerPath="C:\Users\rache\Desktop\dev\eigen-3.3.7"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_video"/>

--- a/plugins/SmartAmp/Source/PluginEditor.cpp
+++ b/plugins/SmartAmp/Source/PluginEditor.cpp
@@ -29,6 +29,10 @@ WaveNetVaAudioProcessorEditor::WaveNetVaAudioProcessorEditor (WaveNetVaAudioProc
     addAndMakeVisible(ampOnButton);
     ampOnButton.addListener(this);
 
+    addAndMakeVisible(loadButton);
+    loadButton.setButtonText("Load Tone");
+    loadButton.addListener(this);
+
     ampCleanLeadButton.setImages(true, true, true,
         ImageCache::getFromMemory(BinaryData::power_switch_up_png, BinaryData::power_switch_up_pngSize), 1.0, Colours::transparentWhite,
         Image(), 1.0, Colours::transparentWhite,
@@ -221,6 +225,8 @@ void WaveNetVaAudioProcessorEditor::resized()
     // This is generally where you'll want to lay out the positions of any
     // subcomponents in your editor..
 
+    loadButton.setBounds(50, 40, 125, 25);
+
     // Amp Widgets
     ampPresenceKnob.setBounds(97, 495, 75, 105);
     ampCleanBassKnob.setBounds(197, 495, 75, 105);
@@ -239,12 +245,27 @@ void WaveNetVaAudioProcessorEditor::resized()
     ampLED.setBounds(975, 160, 15, 25);
 }
 
+void WaveNetVaAudioProcessorEditor::loadButtonClicked()
+{
+    FileChooser chooser("Select a .json tone...",
+        {},
+        "*.json");
+    if (chooser.browseForFileToOpen())
+    {
+        File file = chooser.getResult();
+        processor.loadConfig(file);
+    }
+}
+
 void WaveNetVaAudioProcessorEditor::buttonClicked(juce::Button* button)
 {
-    if (button == &ampOnButton)
+    if (button == &ampOnButton) {
         ampOnButtonClicked();
-    else if (button == &ampCleanLeadButton)
+    } else if (button == &ampCleanLeadButton) {
         ampCleanLeadButtonClicked();
+    } else if (button == &loadButton) {
+        loadButtonClicked();
+    }
 }
 
 

--- a/plugins/SmartAmp/Source/PluginEditor.cpp
+++ b/plugins/SmartAmp/Source/PluginEditor.cpp
@@ -34,7 +34,7 @@ WaveNetVaAudioProcessorEditor::WaveNetVaAudioProcessorEditor (WaveNetVaAudioProc
     loadButton.addListener(this);
 
     addAndMakeVisible(modelLabel);
-    modelLabel.setText("", juce::NotificationType::dontSendNotification);
+    modelLabel.setText(processor.loaded_tone_name, juce::NotificationType::dontSendNotification);
     modelLabel.setJustificationType(juce::Justification::left);
     modelLabel.setColour(juce::Label::textColourId, juce::Colours::black);
 
@@ -158,7 +158,11 @@ WaveNetVaAudioProcessorEditor::WaveNetVaAudioProcessorEditor (WaveNetVaAudioProc
     setSize (1085, 660);
 
     // Load the preset wavenet json model from the project resources
-    processor.loadConfigAmp();
+    if (processor.loaded_tone_name == "") {
+        processor.loadConfigAmp();
+    } else {
+        processor.loadConfig(processor.loaded_tone);
+    }
 }
 
 WaveNetVaAudioProcessorEditor::~WaveNetVaAudioProcessorEditor()
@@ -259,8 +263,10 @@ void WaveNetVaAudioProcessorEditor::loadButtonClicked()
     {
         File file = chooser.getResult();
         processor.loadConfig(file);
-        juce::String fname = file.getFileName();
+        fname = file.getFileName();
         modelLabel.setText(fname, juce::NotificationType::dontSendNotification);
+        processor.loaded_tone = file;
+        processor.loaded_tone_name = fname;
     }
 }
 
@@ -298,6 +304,7 @@ void WaveNetVaAudioProcessorEditor::ampCleanLeadButtonClicked() {
         processor.set_ampEQ(ampLeadBassKnob.getValue(), ampLeadMidKnob.getValue(), ampLeadTrebleKnob.getValue(), ampPresenceKnob.getValue());
     }
     modelLabel.setText("", juce::NotificationType::dontSendNotification);
+    processor.loaded_tone_name = "";
     repaint();
 }
 

--- a/plugins/SmartAmp/Source/PluginEditor.cpp
+++ b/plugins/SmartAmp/Source/PluginEditor.cpp
@@ -33,6 +33,11 @@ WaveNetVaAudioProcessorEditor::WaveNetVaAudioProcessorEditor (WaveNetVaAudioProc
     loadButton.setButtonText("Load Tone");
     loadButton.addListener(this);
 
+    addAndMakeVisible(modelLabel);
+    modelLabel.setText("", juce::NotificationType::dontSendNotification);
+    modelLabel.setJustificationType(juce::Justification::left);
+    modelLabel.setColour(juce::Label::textColourId, juce::Colours::black);
+
     ampCleanLeadButton.setImages(true, true, true,
         ImageCache::getFromMemory(BinaryData::power_switch_up_png, BinaryData::power_switch_up_pngSize), 1.0, Colours::transparentWhite,
         Image(), 1.0, Colours::transparentWhite,
@@ -226,7 +231,7 @@ void WaveNetVaAudioProcessorEditor::resized()
     // subcomponents in your editor..
 
     loadButton.setBounds(50, 40, 125, 25);
-
+    modelLabel.setBounds(50, 65, 400, 25);
     // Amp Widgets
     ampPresenceKnob.setBounds(97, 495, 75, 105);
     ampCleanBassKnob.setBounds(197, 495, 75, 105);
@@ -254,6 +259,8 @@ void WaveNetVaAudioProcessorEditor::loadButtonClicked()
     {
         File file = chooser.getResult();
         processor.loadConfig(file);
+        juce::String fname = file.getFileName();
+        modelLabel.setText(fname, juce::NotificationType::dontSendNotification);
     }
 }
 
@@ -290,6 +297,7 @@ void WaveNetVaAudioProcessorEditor::ampCleanLeadButtonClicked() {
         processor.loadConfigAmp();
         processor.set_ampEQ(ampLeadBassKnob.getValue(), ampLeadMidKnob.getValue(), ampLeadTrebleKnob.getValue(), ampPresenceKnob.getValue());
     }
+    modelLabel.setText("", juce::NotificationType::dontSendNotification);
     repaint();
 }
 

--- a/plugins/SmartAmp/Source/PluginEditor.cpp
+++ b/plugins/SmartAmp/Source/PluginEditor.cpp
@@ -158,7 +158,7 @@ WaveNetVaAudioProcessorEditor::WaveNetVaAudioProcessorEditor (WaveNetVaAudioProc
     setSize (1085, 660);
 
     // Load the preset wavenet json model from the project resources
-    if (processor.loaded_tone_name == "") {
+    if (processor.custom_tone == 0) {
         processor.loadConfigAmp();
     } else {
         processor.loadConfig(processor.loaded_tone);
@@ -267,6 +267,7 @@ void WaveNetVaAudioProcessorEditor::loadButtonClicked()
         modelLabel.setText(fname, juce::NotificationType::dontSendNotification);
         processor.loaded_tone = file;
         processor.loaded_tone_name = fname;
+        processor.custom_tone = 1;
     }
 }
 
@@ -305,6 +306,7 @@ void WaveNetVaAudioProcessorEditor::ampCleanLeadButtonClicked() {
     }
     modelLabel.setText("", juce::NotificationType::dontSendNotification);
     processor.loaded_tone_name = "";
+    processor.custom_tone = 0;
     repaint();
 }
 

--- a/plugins/SmartAmp/Source/PluginEditor.h
+++ b/plugins/SmartAmp/Source/PluginEditor.h
@@ -60,6 +60,7 @@ private:
     int current_background = 1;
 
     TextButton loadButton;
+    Label modelLabel;
     virtual void buttonClicked(Button* button) override;
     void loadButtonClicked();
     virtual void sliderValueChanged(Slider* slider) override;

--- a/plugins/SmartAmp/Source/PluginEditor.h
+++ b/plugins/SmartAmp/Source/PluginEditor.h
@@ -59,7 +59,9 @@ private:
     Image background;
     int current_background = 1;
 
+    TextButton loadButton;
     virtual void buttonClicked(Button* button) override;
+    void loadButtonClicked();
     virtual void sliderValueChanged(Slider* slider) override;
     void ampOnButtonClicked();
     void ampCleanLeadButtonClicked();

--- a/plugins/SmartAmp/Source/PluginEditor.h
+++ b/plugins/SmartAmp/Source/PluginEditor.h
@@ -61,6 +61,7 @@ private:
 
     TextButton loadButton;
     Label modelLabel;
+    juce::String fname;
     virtual void buttonClicked(Button* button) override;
     void loadButtonClicked();
     virtual void sliderValueChanged(Slider* slider) override;

--- a/plugins/SmartAmp/Source/PluginProcessor.cpp
+++ b/plugins/SmartAmp/Source/PluginProcessor.cpp
@@ -163,9 +163,9 @@ void WaveNetVaAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuff
         //    Master Volume 
         buffer.applyGain(ampMaster);
 
-        if (amp_lead == 1) {// add extra clean boost because this particular clean model is very quiet
-            buffer.applyGain(15.0);
-        }
+        //if (amp_lead == 1) {// add extra clean boost because this particular clean model is very quiet
+            //buffer.applyGain(15.0);
+        //}
 
     }
     

--- a/plugins/SmartAmp/Source/PluginProcessor.cpp
+++ b/plugins/SmartAmp/Source/PluginProcessor.cpp
@@ -163,9 +163,9 @@ void WaveNetVaAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuff
         //    Master Volume 
         buffer.applyGain(ampMaster);
 
-        //if (amp_lead == 1) {// add extra clean boost because this particular clean model is very quiet
-            //buffer.applyGain(15.0);
-        //}
+        if (amp_lead == 1 && custom_tone == 0 ) {// add extra clean boost because this particular clean model is very quiet
+            buffer.applyGain(8.0);
+        }
 
     }
     

--- a/plugins/SmartAmp/Source/PluginProcessor.cpp
+++ b/plugins/SmartAmp/Source/PluginProcessor.cpp
@@ -231,6 +231,22 @@ void WaveNetVaAudioProcessor::loadConfigAmp()
     this->suspendProcessing(false);
 }
 
+void WaveNetVaAudioProcessor::loadConfig(File configFile)
+{
+    this->suspendProcessing(true);
+    WaveNetLoader loader(dummyVar, configFile);
+    int numChannels = loader.numChannels;
+    int inputChannels = loader.inputChannels;
+    int outputChannels = loader.outputChannels;
+    int filterWidth = loader.filterWidth;
+    std::vector<int> dilations = loader.dilations;
+    std::string activation = loader.activation;
+    waveNet.setParams(inputChannels, outputChannels, numChannels, filterWidth, activation,
+        dilations);
+    loader.loadVariables(waveNet);
+    this->suspendProcessing(false);
+}
+
 float WaveNetVaAudioProcessor::convertLogScale(float in_value, float x_min, float x_max, float y_min, float y_max)
 {
     float b = log(y_max / y_min) / (x_max - x_min);

--- a/plugins/SmartAmp/Source/PluginProcessor.h
+++ b/plugins/SmartAmp/Source/PluginProcessor.h
@@ -75,6 +75,8 @@ public:
     // Pedal/amp states
     int amp_state = 1; // 0 = off, 1 = on
     int amp_lead = 1; // 1 = clean, 0 = lead
+    File loaded_tone;
+    juce::String loaded_tone_name;
 
     // Amp knob states
     float ampPresenceKnobState = 0.0;

--- a/plugins/SmartAmp/Source/PluginProcessor.h
+++ b/plugins/SmartAmp/Source/PluginProcessor.h
@@ -75,6 +75,7 @@ public:
     // Pedal/amp states
     int amp_state = 1; // 0 = off, 1 = on
     int amp_lead = 1; // 1 = clean, 0 = lead
+    int custom_tone = 0; // 0 = custom tone loaded, 1 = default channel tone
     File loaded_tone;
     juce::String loaded_tone_name;
 

--- a/plugins/SmartAmp/Source/PluginProcessor.h
+++ b/plugins/SmartAmp/Source/PluginProcessor.h
@@ -59,6 +59,7 @@ public:
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     void loadConfigAmp();
+    void loadConfig(File configFile);
 
     // Overdrive Pedal
     float convertLogScale(float in_value, float x_min, float x_max, float y_min, float y_max);
@@ -97,6 +98,8 @@ private:
     float ampCleanDrive = 1.0;
     float ampLeadDrive = 1.0;
     float ampMaster = 1.0;
+
+    var dummyVar;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (WaveNetVaAudioProcessor)

--- a/plugins/SmartAmp/Source/WaveNetLoader.cpp
+++ b/plugins/SmartAmp/Source/WaveNetLoader.cpp
@@ -25,6 +25,19 @@ WaveNetLoader::WaveNetLoader(var jsonFile)
     dilations = readDilations();
 }
 
+WaveNetLoader::WaveNetLoader(var jsonFile, File configFile)
+{
+    // Edit this line to point to your binary json file in project resources
+    config = JSON::parse(configFile);
+
+    numChannels = config["residual_channels"];
+    inputChannels = config["input_channels"];
+    outputChannels = config["output_channels"];
+    filterWidth = config["filter_width"];
+    activation = config["activation"].toString().toStdString();
+    dilations = readDilations();
+}
+
 std::vector<int> WaveNetLoader::readDilations()
 {
     std::vector<int> newDilations;

--- a/plugins/SmartAmp/Source/WaveNetLoader.h
+++ b/plugins/SmartAmp/Source/WaveNetLoader.h
@@ -21,6 +21,7 @@ class WaveNetLoader
 {
 public:
     WaveNetLoader(var jsonFile);
+    WaveNetLoader(var jsonFile, File configFile);
     int numChannels;
     int inputChannels;
     int outputChannels;


### PR DESCRIPTION
Added Load Tone button to the SmartAmp to load json models.  The custom tone is unloaded by switching the clean/lead channel. The current channel's settings are used for the custom tone.